### PR TITLE
fetch: Increase look back to 2 hours

### DIFF
--- a/js/fetch.js
+++ b/js/fetch.js
@@ -12,7 +12,7 @@ const CAT_LABEL_STYLE = {
 }
 
 function requestGeoData() {
-    const minutesToSubtract = 60;
+    const minutesToSubtract = 120;
     const currentDate = new Date();
     const time = new Date(currentDate.getTime() - minutesToSubtract * 60000);
     const utcDate = time.toISOString();


### PR DESCRIPTION
FIUNA sensors data don't update in real-time as ours,
and there's a bunch of other delays that makes it so
that their  sensors  measurements are always one hour
back borderline, and thus  don't always show up.

By increasing the look back time to 2 hours we can
compensate for all those delays.